### PR TITLE
Fix installation instructions in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,7 +122,7 @@ Crypter is also on [Homebrew Cask](https://formulae.brew.sh/cask/crypter) for
 macOS. So to install it, simply run the following command in the Terminal:
 
 ```bash
-$ brew cask install crypter@4.0.0
+$ brew install --cask crypter@4.0.0
 ```
 
 <br/>


### PR DESCRIPTION
Fix error when installing using latest Homebrew. This is not a bug of this app, but readme needs to be fixed.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103161919-74301080-482c-11eb-898a-35d882b0a198.png)
